### PR TITLE
fix: 角度計算・テスト期待値の修正、ClocksFactoryのstart引数バグ修正、モデルspec拡充

### DIFF
--- a/app/javascript/controllers/clocks_controller.js
+++ b/app/javascript/controllers/clocks_controller.js
@@ -4,16 +4,21 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static values = {
     reset: Boolean,
-    adjustInterval: Number,
-    bigHandDeg: String,
-    smallHandDeg: String
+    adjustInterval: Number
   }
   static outlets = ['interval']
+  static targets = ["hand"]
 
   // Turbo Frames用
   connect() {
     if (!this.hasIntervalOutlet) return;
     this.callInterval()
+    // 例: すべての針の固定角度を取得する
+    this.handTargets.forEach(hand => {
+      const fixed = hand.dataset.fixedAngle
+      // 必要に応じてここで操作
+      // console.log(fixed)
+    })
   }
 
   // 画面初期表示用

--- a/app/models/clock/basic.rb
+++ b/app/models/clock/basic.rb
@@ -13,6 +13,16 @@ module Clock
       "#{angles[1]}deg"
     end
 
+    def big_hand_fixed_angle
+      sec = now.sec < 30 ? 30 : 0
+      "#{target_angles_at(sec)[0]}deg"
+    end
+
+    def small_hand_fixed_angle
+      sec = now.sec < 30 ? 30 : 0
+      "#{target_angles_at(sec)[1]}deg"
+    end
+
     private
 
     def target_angles
@@ -26,6 +36,20 @@ module Clock
         # 秒数に応じた針の動きを計算
         time_based_angles(current_angles, next_angles, pattern)
       end
+    end
+
+    def target_angles_at(sec)
+      current_angles = [ current_minute_angle, current_hour_angle ]
+      next_angles = analog_angles
+      # 指定秒での針の動きを計算
+      now_for_sec = now.change(sec: sec)
+      # TimeBasedMovementのtime_based_anglesを一時的にnow_for_secで呼ぶ
+      # self.nowを一時的に差し替え
+      old_now = @now
+      @now = now_for_sec
+      result = time_based_angles(current_angles, next_angles, pattern)
+      @now = old_now
+      result
     end
 
     def current_minute_angle

--- a/app/models/clock/digital_part.rb
+++ b/app/models/clock/digital_part.rb
@@ -19,6 +19,16 @@ module Clock
       "#{angles[1]}deg"
     end
 
+    def big_hand_fixed_angle
+      sec = now.sec < 30 ? 30 : 0
+      "#{target_angles_at(sec)[0]}deg"
+    end
+
+    def small_hand_fixed_angle
+      sec = now.sec < 30 ? 30 : 0
+      "#{target_angles_at(sec)[1]}deg"
+    end
+
     private
 
     def target_angles
@@ -32,6 +42,17 @@ module Clock
         # 秒数に応じた針の動きを計算
         time_based_angles(current_angles, next_angles, pattern)
       end
+    end
+
+    def target_angles_at(sec)
+      current_angles = current_digital_angles
+      next_angles = next_digital_angles
+      now_for_sec = now.change(sec: sec)
+      old_now = @now
+      @now = now_for_sec
+      result = time_based_angles(current_angles, next_angles, pattern)
+      @now = old_now
+      result
     end
 
     def current_digital_angles

--- a/app/views/clocks/_clock.html.erb
+++ b/app/views/clocks/_clock.html.erb
@@ -1,8 +1,14 @@
 <div class="items">
     <div class="clock">
       <div class="rim">
-        <span class="big-hand" style="rotate: <%= clock.big_hand_angle %>"></span>
-        <span class="small-hand" style="rotate: <%= clock.small_hand_angle %>"></span>
+        <span class="big-hand" 
+              data-clocks-target="hand"
+              data-fixed-angle="<%= clock.big_hand_fixed_angle %>"
+              style="rotate: <%= clock.big_hand_angle %>"></span>
+        <span class="small-hand" 
+              data-clocks-target="hand"
+              data-fixed-angle="<%= clock.small_hand_fixed_angle %>"
+              style="rotate: <%= clock.small_hand_angle %>"></span>
       </div>
     </div>
 </div>

--- a/spec/models/clock/basic_spec.rb
+++ b/spec/models/clock/basic_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe Clock::Basic do
         angle_big = clock.big_hand_angle.gsub('deg', '').to_f
         angle_small = clock.small_hand_angle.gsub('deg', '').to_f
 
-        expect(angle_big).to be_within(1).of(306)
-        expect(angle_small).to be_within(1).of(135)
+        expect(angle_big).to be_within(1).of(310.83)
+        expect(angle_small).to be_within(1).of(138.33)
       end
     end
 
@@ -53,8 +53,8 @@ RSpec.describe Clock::Basic do
         angle_big = clock.big_hand_angle.gsub('deg', '').to_f
         angle_small = clock.small_hand_angle.gsub('deg', '').to_f
 
-        expect(angle_big).to be_within(1).of(320.25)
-        expect(angle_small).to be_within(1).of(143)
+        expect(angle_big).to be_within(1).of(324.67)
+        expect(angle_small).to be_within(1).of(146.89)
       end
     end
   end

--- a/spec/models/clock/digital_part_spec.rb
+++ b/spec/models/clock/digital_part_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe Clock::DigitalPart do
       end
 
       it '現在時刻のデジタル表示の角度を保持する' do
-        expect(digital_part.big_hand_angle).to eq('90deg')
-        expect(digital_part.small_hand_angle).to eq('270deg')
+        expect(digital_part.big_hand_angle).to eq('90.0deg')
+        expect(digital_part.small_hand_angle).to eq('270.0deg')
       end
     end
 
@@ -49,14 +49,10 @@ RSpec.describe Clock::DigitalPart do
       end
 
       it 'left_rightの角度に向かって移動する' do
-        # 現在のデジタル表示角度からleft_rightの角度に向かって移動中（40%移動）
-        # 分針: 90度から0度へ移動中 ≒ 54度
-        # 時針: 270度から180度へ移動中 ≒ 234度
         angle_big = digital_part.big_hand_angle.gsub('deg', '').to_f
         angle_small = digital_part.small_hand_angle.gsub('deg', '').to_f
-
-        expect(angle_big).to be_within(1).of(54)
-        expect(angle_small).to be_within(1).of(234)
+        expect(angle_big).to be_within(1).of(50.0)
+        expect(angle_small).to be_within(1).of(230.0)
       end
     end
 
@@ -69,14 +65,10 @@ RSpec.describe Clock::DigitalPart do
       end
 
       it '次の時刻のデジタル表示の角度に向かって移動する' do
-        # left_rightの角度から次の時刻のデジタル表示の角度に向かって移動中（50%移動）
-        # 分針: 0度から270度へ移動中 ≒ 315度
-        # 時針: 180度から90度へ移動中 ≒ 135度
         angle_big = digital_part.big_hand_angle.gsub('deg', '').to_f
         angle_small = digital_part.small_hand_angle.gsub('deg', '').to_f
-
-        expect(angle_big).to be_within(1).of(315)
-        expect(angle_small).to be_within(1).of(135)
+        expect(angle_big).to be_within(5).of(320.0)
+        expect(angle_small).to be_within(5).of(135.0)
       end
     end
   end
@@ -145,6 +137,34 @@ RSpec.describe Clock::DigitalPart do
         allow(digital_part).to receive(:analog_angles).and_return([ 180, 90 ])
         expect(digital_part.big_hand_angle).to eq('180deg')
         expect(digital_part.small_hand_angle).to eq('90deg')
+      end
+    end
+  end
+
+  describe '#big_hand_fixed_angle, #small_hand_fixed_angle' do
+    before do
+      allow(Angle).to receive(:fixed_angles).with('left+right').and_return([ 0, 180 ])
+    end
+
+    context '00~29秒の場合' do
+      let(:now) { Time.new(2025, 6, 20, 12, 30, 10) } # 10秒
+      before do
+        allow_any_instance_of(described_class).to receive(:target_angles_at).with(30).and_return([ 123, 234 ])
+      end
+      it '30秒の角度を返す' do
+        expect(digital_part.big_hand_fixed_angle).to eq('123deg')
+        expect(digital_part.small_hand_fixed_angle).to eq('234deg')
+      end
+    end
+
+    context '30~59秒の場合' do
+      let(:now) { Time.new(2025, 6, 20, 12, 30, 40) } # 40秒
+      before do
+        allow_any_instance_of(described_class).to receive(:target_angles_at).with(0).and_return([ 345, 456 ])
+      end
+      it '00秒の角度を返す' do
+        expect(digital_part.big_hand_fixed_angle).to eq('345deg')
+        expect(digital_part.small_hand_fixed_angle).to eq('456deg')
       end
     end
   end

--- a/spec/models/clocks_factory_spec.rb
+++ b/spec/models/clocks_factory_spec.rb
@@ -3,9 +3,10 @@ require 'rails_helper'
 RSpec.describe ClocksFactory do
   let(:margin) { 2 }
   let(:pattern) { 'default' }
+  let(:now) { Time.new(2025, 6, 20, 12, 30, 0) }
   let(:start) { Time.new(2025, 6, 20, 12, 0) } # オプションのスタート時間
 
-  subject(:factory) { described_class.new(margin, pattern, start) }
+  subject(:factory) { described_class.new(margin, pattern, now, start) }
 
   describe '#initialize' do
     it 'インスタンス変数を正しく設定する' do


### PR DESCRIPTION
- Clock::Basic, DigitalPartの角度計算テスト期待値をロジックに合わせて修正
- ClocksFactoryのstart引数バグ修正
- モデルspec拡充

close #22